### PR TITLE
Deprecated Discovery

### DIFF
--- a/nupnp.go
+++ b/nupnp.go
@@ -3,7 +3,7 @@ package hue
 import "encoding/json"
 import "net/http"
 
-const nupnpEndpoint = "https://www.meethue.com/api/nupnp"
+const nupnpEndpoint = "https://discovery.meethue.com/"
 
 type nupnpBridge struct {
 	Serial string `json:"id"`


### PR DESCRIPTION
> **Bridge Discovery Endpoint Change**
> Effective July 1 2018 (nupnp) bridge discovery is supported by a new endpoint, which is https://discovery.meethue.com. The old endpoint  www.meethue.com/api/nupnp has been deprecated but remains available until July 1 2019. We had to change to the new endpoint such that we can guarantee a high reliability with the increased amount of traffic we are getting. There are no other differences besides the url. If you experience issues, please let us know.

Source: https://developers.meethue.com/news/